### PR TITLE
Use one variable for AB/AA test simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,21 @@ confidence interval and plot of p-value distribution for different tests.
 ```
 from abtoolkit.continuous.simulation import StatTestsSimulation
 simulation = StatTestsSimulation(
-    control,
-    test,
-    stattests_list=["ttest", "regression_test", "cuped_ttest", "did_regression_test", "additional_vars_regression_test"],
-    alternative="two-sided",
-    experiments_num=experiments_num,
-    sample_size=sample_size,
-    mde=mde,
-    alpha_level=alpha_level,
+        variable,
+        
+        stattests_list=["ttest", "diff_ttest", "regression_test", "cuped_ttest", "did_regression_test",
+                        "additional_vars_regression_test"],
+                        
+        alternative=alternative,
+        experiments_num=experiments_num,
+        sample_size=sample_size,
+        mde=mde,
+        alpha_level=alpha_level,
 
-    control_previous_values=control_previous_value,
-    test_previous_values=test_previous_value,
-    control_cuped_covariant=control_previous_value,
-    test_cuped_covariant=test_previous_value,
-    control_additional_vars=[control_previous_value],
-    test_additional_vars=[test_previous_value],
-)
+        previous_values=previous_value,
+        cuped_covariant=previous_value,
+        additional_vars=[previous_value],
+    )
 simulation.run()  # Run simulation
 simulation.print_results()  # Print results of simulation
 simulation.plot_p_values()  # Plot p-values distribution

--- a/examples/continuous_var_analysis.py
+++ b/examples/continuous_var_analysis.py
@@ -14,25 +14,19 @@ if __name__ == '__main__':
     experiments_num = 200  # Number of experiments to run for each stattest
     alternative = 'two-sided'
 
-    # Generate test variable
-    test_sr = generate_data(examples_num)
-    # Generate previous value of test variable (will be used to reduce variance) and speedup tests
-    test_previous_value = generate_data(examples_num, index=test_sr.index).rename("prev")
-
-    # Generate control variable
-    control_sr = generate_data(examples_num)
-    # Generate previous value of control variable (will be used to reduce variance) and speedup tests
-    control_previous_value = generate_data(examples_num, index=control_sr.index).rename("prev")
+    # Generate variable
+    variable = generate_data(examples_num)
+    # Generate previous value of variable (will be used to reduce variance) and speedup tests
+    previous_value = generate_data(examples_num, index=variable.index).rename("prev")
 
     # Estimate sample_size need for test
     sample_size = estimate_sample_size_by_mde(
-        std=np.concatenate([control_sr, test_sr], axis=0).std(),
+        std=variable.std(),
         alpha=alpha_level, power=power, mde=mde, alternative=alternative)
     print(f"Minimum sample size for each group is {sample_size}")
 
     sim = StatTestsSimulation(
-        control_sr,
-        test_sr,
+        variable,
         stattests_list=["ttest", "diff_ttest", "regression_test", "cuped_ttest", "did_regression_test",
                         "additional_vars_regression_test"],
         alternative=alternative,
@@ -41,12 +35,9 @@ if __name__ == '__main__':
         mde=mde,  # Trying to detect this effect (very big for our simulated data)
         alpha_level=alpha_level,  # Fix alpha level on 5%
 
-        control_previous_values=control_previous_value,
-        test_previous_values=test_previous_value,
-        control_cuped_covariant=control_previous_value,
-        test_cuped_covariant=test_previous_value,
-        control_additional_vars=[control_previous_value],
-        test_additional_vars=[test_previous_value],
+        previous_values=previous_value,
+        cuped_covariant=previous_value,
+        additional_vars=[previous_value],
     )
     info = sim.run()  # Get dictionary with information about tests
     sim.print_results()  # Print results of simulation

--- a/tests/test_continuous_simulation.py
+++ b/tests/test_continuous_simulation.py
@@ -8,17 +8,13 @@ class TestStatTestsSimulation(unittest.TestCase):
              "did_regression_test", "additional_vars_regression_test"]
 
     def test_success(self):
-        test_sr = generate_data(100)
-        test_previous_value = generate_data(100, index=test_sr.index).rename("prev")
-
-        control_sr = generate_data(100)
-        control_previous_value = generate_data(100, index=control_sr.index).rename("prev")
+        variable = generate_data(100)
+        previous_value = generate_data(100, index=variable.index).rename("prev")
 
         experiments_num = 10
 
         sim = StatTestsSimulation(
-            control_sr,
-            test_sr,
+            variable,
             stattests_list=self.tests,
             experiments_num=experiments_num,
             alternative="two-sided",
@@ -27,12 +23,9 @@ class TestStatTestsSimulation(unittest.TestCase):
             alpha_level=0.05,
             power=0.8,
 
-            control_previous_values=control_previous_value,
-            test_previous_values=test_previous_value,
-            control_cuped_covariant=control_previous_value,
-            test_cuped_covariant=test_previous_value,
-            control_additional_vars=[control_previous_value],
-            test_additional_vars=[test_previous_value],
+            previous_values=previous_value,
+            cuped_covariant=previous_value,
+            additional_vars=[previous_value],
         )
         info = sim.run()
 


### PR DESCRIPTION
Removed test and control variables, keep only one variable to perform AA and AB tests on it