### PR TITLE
Fix continuous diff-ttest wiring and one-sided handling for discrete sample-size calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ of treatment impact.
 from abtoolkit.discrete.utils import estimate_sample_size_by_mde
 
 estimate_sample_size_by_mde(
-    p, 
-    sample_size, 
-    alpha=0.05,
-    alternative="two-sided"
+    p=p,
+    alpha=alpha_level,
+    power=power,
+    mde=mde,
+    alternative="two-sided",
 )
 ```
 #### AA and AB tests simulation:

--- a/abtoolkit/continuous/simulation.py
+++ b/abtoolkit/continuous/simulation.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from abtoolkit.continuous.stattests import additional_vars_regression_test
 from abtoolkit.continuous.stattests import cuped_ttest
+from abtoolkit.continuous.stattests import difference_ttest
 from abtoolkit.continuous.stattests import did_regression_test
 from abtoolkit.continuous.stattests import regression_test
 from abtoolkit.continuous.stattests import ttest
@@ -111,7 +112,13 @@ class StatTestsSimulation(BaseSimulationClass):
         treatment_pre_sample = self.previous_values.loc[treatment_index_sample]
         treatment_sample += mde
 
-        return cuped_ttest(control_sample, control_pre_sample, treatment_sample, treatment_pre_sample, self.alternative)
+        return difference_ttest(
+            control_sample,
+            control_pre_sample,
+            treatment_sample,
+            treatment_pre_sample,
+            self.alternative,
+        )
 
     def simulate_cuped(self, mde: float) -> float:
         """

--- a/abtoolkit/discrete/utils.py
+++ b/abtoolkit/discrete/utils.py
@@ -30,11 +30,8 @@ def estimate_sample_size_by_mde(
     :return: sample size needed for each group
     """
 
-    # Todo: When alternative = "less" or "greater" we get undersampling (power less then 0.8).
     if alternative == "two-sided":
-        pass
-
-    alpha = alpha / 2
+        alpha = alpha / 2
 
     z = stats.norm.ppf(q=1 - alpha) + stats.norm.ppf(q=power)
     size = 2 * p * (1 - p) * (z / mde) ** 2
@@ -62,11 +59,8 @@ def estimate_mde_by_sample_size(
     :return: minimum detectable effect
     """
 
-    # Todo: When alternative = "less" or "greater" we get undersampling (power less then 0.8).
     if alternative == "two-sided":
-        pass
-
-    alpha = alpha / 2
+        alpha = alpha / 2
 
     z = stats.norm.ppf(q=1 - alpha) + stats.norm.ppf(q=power)
     # size = 2 * p * (1 - p) * (z / mde) ** 2

--- a/tests/test_continuous_simulation.py
+++ b/tests/test_continuous_simulation.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+
 from abtoolkit.continuous.simulation import StatTestsSimulation
 from abtoolkit.utils import generate_data
 
@@ -106,3 +108,24 @@ class TestStatTestsSimulation(unittest.TestCase):
             self.assertTrue("ab_pvalues" in test_info, f"AB p-values not in result dict")
             self.assertTrue(len(test_info["ab_pvalues"]) == experiments_num,
                             f"Number of p-values in AB test doesn't match with number of experiments")
+
+
+    def test_diff_ttest_uses_difference_ttest(self):
+        variable = generate_data(30, distribution_type="cont")
+        previous_value = generate_data(30, distribution_type="cont", index=variable.index).rename("prev")
+
+        sim = StatTestsSimulation(
+            variable,
+            stattests_list=["diff_ttest"],
+            experiments_num=1,
+            alternative="two-sided",
+            treatment_sample_size=10,
+            treatment_split_proportion=0.5,
+            mde=1,
+            previous_values=previous_value,
+        )
+
+        with patch("abtoolkit.continuous.simulation.difference_ttest", return_value=0.5) as diff_mock:
+            sim.simulate_difference_ttest(mde=0)
+
+        self.assertTrue(diff_mock.called, "diff_ttest simulation should call difference_ttest")

--- a/tests/test_discrete_utils.py
+++ b/tests/test_discrete_utils.py
@@ -15,6 +15,19 @@ class TestSampleSizeEstimation(unittest.TestCase):
         self.assertTrue(isinstance(mde, float), "Estimated MDE has wrong type")
         self.assertTrue(mde > 0, f"Estimated MDE is negative: {mde}")
 
+
+    def test_one_sided_requires_smaller_sample_than_two_sided(self):
+        two_sided = estimate_sample_size_by_mde(0.07, 0.05, 0.8, 0.03, alternative="two-sided")
+        one_sided = estimate_sample_size_by_mde(0.07, 0.05, 0.8, 0.03, alternative="greater")
+
+        self.assertTrue(one_sided < two_sided, "One-sided test should require a smaller sample size")
+
+    def test_one_sided_has_smaller_mde_than_two_sided(self):
+        two_sided = estimate_mde_by_sample_size(0.07, 0.05, 0.8, 1136, alternative="two-sided")
+        one_sided = estimate_mde_by_sample_size(0.07, 0.05, 0.8, 1136, alternative="greater")
+
+        self.assertTrue(one_sided < two_sided, "One-sided test should detect a smaller MDE")
+
     def test_estimate_ci_binomial(self):
         ci = estimate_ci_binomial(0.07, 1136, 0.5)
         self.assertTrue(len(ci) == 2, f"Got wrong confidence interval: {ci}")


### PR DESCRIPTION
### Motivation
- `simulate_difference_ttest` in the continuous simulation was mistakenly calling the wrong test implementation which yields incorrect p-values for the Diff-in-Diff simulation. 
- Discrete sample-size and MDE helper functions were halving `alpha` for all alternatives instead of only for two-sided tests, producing wrong one-sided estimates. 
- README example for discrete sample-size estimation did not match the function signature and could confuse users.

### Description
- Replace the incorrect call by importing and calling `difference_ttest` from `abtoolkit.continuous.stattests` in `abtoolkit/continuous/simulation.py`. 
- Fix `alpha` handling in `abtoolkit/discrete/utils.py` so `alpha` is halved only when `alternative == "two-sided"`. 
- Update README example to match the actual `estimate_sample_size_by_mde` signature for discrete variables. 
- Add unit tests: `test_diff_ttest_uses_difference_ttest` to assert the simulation wiring, and two one-sided vs two-sided tests in `tests/test_discrete_utils.py` to assert expected sample-size/MDE ordering.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`31 passed`).
- Ran focused tests with `pytest -q tests/test_discrete_utils.py tests/test_continuous_simulation.py` and the targeted tests passed (`8 passed`).
- All newly added tests for the fixes passed in CI-local runs, confirming the corrected behavior of `diff_ttest` wiring and one-sided discrete calculations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ac1676588326baf3ab7bb7fcccb1)